### PR TITLE
Add missing 'Test' event declaration to HalvingToken.sol

### DIFF
--- a/contracts/HalvingToken.sol
+++ b/contracts/HalvingToken.sol
@@ -18,6 +18,8 @@ contract HalvingToken is
 
     uint256 private _currentBlock;
 
+    event Test(uint256 indexed cycle, uint256 reward, uint256 blockNumber);
+
     /// @notice Initializes the contract with a name, symbol, cap
     constructor()
         ERC20("BTC Halving Token", "BTCHV")


### PR DESCRIPTION
This commit resolves the 'DeclarationError: Undeclared identifier' encountered when emitting the 'Test' event in the mint function. The 'Test' event is now properly declared with appropriate parameters, which logs the current cycle, reward amount, and block number upon token minting.
